### PR TITLE
Replace the embedded database with testcontainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <graalvm.version>21.1.0</graalvm.version>
+    <testcontainers.version>1.16.2</testcontainers.version>
   </properties>
   <dependencies>
     <dependency>
@@ -125,6 +126,30 @@
       <version>4.2.0</version>
     </dependency>
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mysql</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>5.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna-platform</artifactId>
+      <version>5.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.graalvm.sdk</groupId>
       <artifactId>graal-sdk</artifactId>
       <version>${graalvm.version}</version>
@@ -197,35 +222,6 @@
                   <version>${project.version}</version>
                 </path>
               </annotationProcessorPaths>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <id>db-start</id>
-            <phase>test-compile</phase>
-            <goals>
-              <goal>java</goal>
-            </goals>
-            <configuration>
-              <mainClass>io.vlingo.xoom.turbo.storage.EmbeddedDatabaseInitializer</mainClass>
-              <cleanupDaemonThreads>false</cleanupDaemonThreads>
-            </configuration>
-          </execution>
-          <execution>
-            <id>db-close</id>
-            <phase>post-integration-test</phase>
-            <goals>
-              <goal>java</goal>
-            </goals>
-            <configuration>
-              <mainClass>io.vlingo.xoom.turbo.storage.EmbeddedDatabaseStopper</mainClass>
-              <cleanupDaemonThreads>false</cleanupDaemonThreads>
             </configuration>
           </execution>
         </executions>

--- a/src/test/java/io/vlingo/xoom/turbo/annotation/initializer/XoomInitializerTest.java
+++ b/src/test/java/io/vlingo/xoom/turbo/annotation/initializer/XoomInitializerTest.java
@@ -11,10 +11,12 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.net.URL;
 
+import io.vlingo.xoom.turbo.testcontainers.SharedMySQLContainer;
 import org.junit.After;
 import org.junit.Test;
 
 public class XoomInitializerTest {
+    private SharedMySQLContainer mysqlContainer = SharedMySQLContainer.getInstance();
 
     @Test
     public void testInitialization() throws Exception {

--- a/src/test/java/io/vlingo/xoom/turbo/testcontainers/SharedMySQLContainer.java
+++ b/src/test/java/io/vlingo/xoom/turbo/testcontainers/SharedMySQLContainer.java
@@ -1,0 +1,49 @@
+package io.vlingo.xoom.turbo.testcontainers;
+
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class SharedMySQLContainer extends MySQLContainer<SharedMySQLContainer> {
+  private static final DockerImageName image = DockerImageName.parse("mysql/mysql-server:latest").asCompatibleSubstituteFor("mysql");
+  private static SharedMySQLContainer instance;
+
+  private SharedMySQLContainer() {
+    super(image);
+  }
+
+  @SuppressWarnings("resource")
+  public static SharedMySQLContainer getInstance() {
+    if (instance == null) {
+      String username = "xoom_test";
+      String databaseName = "STORAGE_TEST";
+      String password = "vlingo123";
+      instance = new SharedMySQLContainer()
+          .withEnv("MYSQL_ROOT_HOST", "%")
+          .withDatabaseName(databaseName)
+          .withExposedPorts(3306)
+          .withPassword(password);
+      instance.start();
+      instance.createUser(username, password);
+      instance.withUsername(username);
+    }
+    return instance;
+  }
+
+  @Override
+  public void stop() {
+    // do nothing, the JVM handles shut down
+  }
+
+  private void createUser(String username, String password) {
+    try (Connection connection = DriverManager.getConnection(getJdbcUrl(), "root", getPassword())) {
+      connection.createStatement().executeUpdate(String.format("CREATE USER '%s'@'%%' IDENTIFIED BY '%s';", username, password));
+      connection.createStatement().executeUpdate(String.format("GRANT ALL PRIVILEGES ON *.* TO '%s'@'%%';", username));
+    } catch (SQLException cause) {
+      throw new RuntimeException("Failed to create the test user.", cause);
+    }
+  }
+}


### PR DESCRIPTION
This will fix the build on Apple silicon.

I haven't removed the `EmbeddedDatabase`, `EmbeddedDatabaseInitializer`, nor the `EmbeddedDatabaseStopper` as these classes might be still used in a different (non-test) context.